### PR TITLE
fix(Html): wrong code used in right border if statement

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -261,7 +261,7 @@ class Html {
                                 if(strpos($colConfig,"[")!==false){
                                     $style .= "border-left:1px solid black;";$borderStyling=true;
                                 }       
-                                if(strpos($colConfig,"[")!==false){
+                                if(strpos($colConfig,"]")!==false){
                                     $style .= "border-right:1px solid black;";$borderStyling=true;
                                 }        
                                 if(strpos($colConfig,"g")!==false){


### PR DESCRIPTION
The documentation states that this code ( `]` ) should put a right border. But the current implementation got a typo on its logical `if` statement, making the code ( `[` ) generates borders on either side. The code ( `]` ) simply does nothing.

This pull request contains a fix for that.
Please check it out.